### PR TITLE
Fix missing link text

### DIFF
--- a/examples/single_space/example/Gemfile
+++ b/examples/single_space/example/Gemfile
@@ -4,6 +4,10 @@ gem 'jekyll', '~> 3.6', '>= 3.6.3'
 
 gem 'contentful_bootstrap'
 
+gem 'kramdown-parser-gfm'
+
+gem 'webrick'
+
 group :jekyll_plugins do
   gem 'jekyll-contentful-data-import'
 end

--- a/examples/single_space/example/about.md
+++ b/examples/single_space/example/about.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 title: About
 permalink: /about/
 ---

--- a/examples/single_space/example/index.html
+++ b/examples/single_space/example/index.html
@@ -9,7 +9,7 @@ layout: default
   <ul class="post-list">
     {% for link in site.data.contentful.spaces.links.link %}
       <li>
-        <h2><a href="{{ link.url | url }}">{{ link.websiteName }}</a></h2>
+        <h2><a href="{{ link.url | url }}">{{ link.website_name }}</a></h2>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
- Fixed error that was causing links to have empty text
- Fixed Jekyll warning about a missing template file
- Added some gems that were missing using Ruby 3.0.6